### PR TITLE
Add HCL syntax guide and link it to first deploy guide

### DIFF
--- a/first_deploy.md
+++ b/first_deploy.md
@@ -67,7 +67,8 @@ case, we only need the AWS provider. The `variables.tf` section lists the input
 variables that users need to provide. We'll talk more about ways of setting
 these variables later. The `main.tf` section is the actual resource
 configuration. Finally, the `outputs.tf` section defines outputs that we may
-want to get from this later.
+want to get from this later. For more information on syntax of the Terraform
+code, see our [HCL syntax overview](hcl_syntax_overview.md).
 
 ### Deploying your bucket configuration
 

--- a/hcl_syntax_overview.md
+++ b/hcl_syntax_overview.md
@@ -26,7 +26,10 @@ resource "aws_instance" "web" {
 Blocks have a type, label(s) and a body enclosed in braces.
 In the example above `resource` is a type, `"aws_instance"` and `"web"` are labels.
 The block type defines how many labels are required.
-In this example (when working with the AWS provider) the `resource` type requires two labels.
+Blocks have a block type, zero or more block labels, and a body enclosed in braces.
+In the example above `resource` is the block type, `"aws_instance"` and `"web"` are block labels.
+The block type defines how many labels are required.
+In this example (which uses the AWS provider) the `resource` block type requires two block labels.
 
 ## Comments
 

--- a/hcl_syntax_overview.md
+++ b/hcl_syntax_overview.md
@@ -84,5 +84,24 @@ tags = {
 }
 ```
 
+## Functions
+
+HCL also supports functions.
+Some functions are built into the language and others are supplied by the provider.
+The syntax for functions looks like `function(arg1, arg2)`.
+For example, the built in function `upper` will return the upper-cased string provided as an argument:
+
+```HCL
+uppercase_name = upper("mike")
+```
+
+Provider supplied functions require the provider name and look like this:
+
+```HCL
+provider::terraform::encode_tfvars({
+  example = "Hello!"
+})
+```
+
 This completes a general overview of HCL syntax.
 To learn more about the language, the [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) is a good resource.

--- a/hcl_syntax_overview.md
+++ b/hcl_syntax_overview.md
@@ -1,0 +1,85 @@
+# HCL Syntax Overview
+
+HCL is a language designed to be relatively easy for humans to read and edit.
+It is not necessary to fully understand the syntax of HCL to use Terraform.
+However, some familiarity will make it easier to modify and extend code examples for your own needs.
+
+## Arguments and Blocks
+
+Arguments assign values to names:
+
+```HCL
+name = "my-server"
+instance_count = 3
+enabled = true
+```
+
+Blocks are containers for other content.
+
+```HCL
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+}
+```
+
+Blocks have a type, label(s) and a body enclosed in braces.
+In the example above `resource` is a type, `"aws_instance"` and `"web"` are labels.
+The block type defines how many labels are required.
+In this example (when working with the AWS provider) the `resource` type requires two labels.
+
+## Comments
+
+HCL supports a few different ways to format comments in HCL code:
+
+```HCL
+# Single line comment
+
+// Also a single line comment
+
+/* Multi-line
+   comment block */
+```
+
+## Data Types
+
+HCL supports several primitive data types:
+
+```HCL
+# Strings
+name = "hello"
+multiline = <<EOF
+This is a
+multiline string
+EOF
+
+# Numbers
+count = 42
+price = 19.99
+
+# Booleans
+enabled = true
+disabled = false
+
+# Null
+value = null
+```
+
+as well as lists:
+
+```HCL
+availability_zones = ["us-west-1a", "us-west-1b"]
+ports = [80, 443, 8080]
+```
+
+and maps:
+
+```HCL
+tags = {
+  Environment = "production"
+  Owner       = "team-platform"
+}
+```
+
+This completes a general overview of HCL syntax.
+To learn more about the language, the [Terraform Language Documentation](https://developer.hashicorp.com/terraform/language) is a good resource.


### PR DESCRIPTION
I opted to link to the guide from the first deploy tutorial since I think it is a useful reference, but I don't think we want to overwhelm our learners with too much information.