### PR TITLE
Add state tutorial

### DIFF
--- a/terraform_state.md
+++ b/terraform_state.md
@@ -10,19 +10,55 @@ local file, it would be better to store this in a remote location. We recommend
 using an S3 bucket for remote state. That bucket should be very locked down,
 since this file can contain sensitive information about your deployment.
 
-In the file `modules/s3backend/main.tf`, we have a configuration for an S3
+In the file `backend/main.tf`, we have a configuration for an S3
 bucket that can be used as a backend for Terraform state. For the purposes of
 this tutorial, you can create that bucket by changing into `modules/s3backend`
 directory and running `tofu plan -out tfplan` and `tofu apply tfplan`. Remember
 that Terraform uses all the `.tf` files in the current directory, but not in
-subdirectories.
+subdirectories. Be sure to remember the name you choose for the bucket, we will need it later
+to tell terraform where to find our state file.
 
 To use that configuration as our backend, we need to configure the `terraform`
 block in our `main.tf` file. Change the existing block to something like this:
 
 ```hcl
+# versions.tf
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+# bucket to store the state
+  backend "s3" {
+    key    = "terraform.tfstate"
+  }
+}
+
+# variables.tf
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+}
+
+# main.tf
+resource "aws_s3_bucket" "my_bucket" {
+  bucket = var.bucket_name
+}
+
+# outputs.tf
+output "bucket_name" {
+  value = aws_s3_bucket.my_bucket.bucket
+}
 ```
 
 In this, we're keeping some of the configuration in outside of the main
 Terraform. That's because some information (in our case, the bucket name) is
 potentially sensitive and shouldn't be kept in a public repository. 
+
+To keep the state bucket's name out of a public repository, we will use an environmental variable `TF_STATE_BUCKET` that we can pass into our `terraform init command`:
+
+```
+terraform init -backend-config="bucket=$TF_STATE_BUCKET"
+```

--- a/terraform_state.md
+++ b/terraform_state.md
@@ -59,11 +59,13 @@ Terraform. That's because some information (in our case, the bucket name) is
 potentially sensitive and shouldn't be kept in a public repository. 
 
 To keep the state bucket's name out of a public repository, we will use an environmental variable `TF_STATE_BUCKET` that we can pass into our `terraform init command`:
+Note, this is just one way to pass this information in, you can also pass in an HCL file that has the backend bucket name.
 
 ```
 export TF_STATE_BUCKET=BUCKET-NAME-YOU-PICKED
 tofu init -backend-config="bucket=$TF_STATE_BUCKET"
 ```
+
 
 You will then get a message that looks like this:
 
@@ -79,3 +81,4 @@ Type "yes" to migrate your local tfstate file to the cloud.
 
 Now when you run `aws s3 ls` you should see 2 buckets listed.
 One bucket should be the name of the bucket you are using to track the state file, and the other bucket name should be the one you created with your modified `main.tf` file.
+You don't need to pass the environmental variable in for future commands since it will store the backend information in the `.terraform/` directory.

--- a/terraform_state.md
+++ b/terraform_state.md
@@ -62,12 +62,12 @@ To keep the state bucket's name out of a public repository, we will use an envir
 
 ```
 export TF_STATE_BUCKET=BUCKET-NAME-YOU-PICKED
-terraform init -backend-config="bucket=$TF_STATE_BUCKET"
+tofu init -backend-config="bucket=$TF_STATE_BUCKET"
 ```
 
-```
 You will then get a message that looks like this:
 
+```
 Do you want to copy existing state to the new backend?
   Pre-existing state was found while migrating the previous "local" backend to the
   newly configured "s3" backend. No existing state was found in the newly

--- a/terraform_state.md
+++ b/terraform_state.md
@@ -78,4 +78,4 @@ Do you want to copy existing state to the new backend?
 Type "yes" to migrate your local tfstate file to the cloud.
 
 Now when you run `aws s3 ls` you should see 2 buckets listed.
-One bucket should be the name of the bucket you are using to track the sate file, and the other bucket name should be the one you created with your modified `main.tf` file.
+One bucket should be the name of the bucket you are using to track the state file, and the other bucket name should be the one you created with your modified `main.tf` file.

--- a/terraform_state.md
+++ b/terraform_state.md
@@ -12,7 +12,7 @@ since this file can contain sensitive information about your deployment.
 
 In the file `backend/main.tf`, we have a configuration for an S3
 bucket that can be used as a backend for Terraform state. For the purposes of
-this tutorial, you can create that bucket by changing into `modules/s3backend`
+this tutorial, you can create that bucket by changing into `backend/main.tf`
 directory and running `tofu plan -out tfplan` and `tofu apply tfplan`. Remember
 that Terraform uses all the `.tf` files in the current directory, but not in
 subdirectories. Be sure to remember the name you choose for the bucket, we will need it later
@@ -33,6 +33,7 @@ terraform {
 # bucket to store the state
   backend "s3" {
     key    = "terraform.tfstate"
+    region = "us-west-2"   # needs to match region of the state bucket made previously 
   }
 }
 
@@ -60,5 +61,21 @@ potentially sensitive and shouldn't be kept in a public repository.
 To keep the state bucket's name out of a public repository, we will use an environmental variable `TF_STATE_BUCKET` that we can pass into our `terraform init command`:
 
 ```
+export TF_STATE_BUCKET=BUCKET-NAME-YOU-PICKED
 terraform init -backend-config="bucket=$TF_STATE_BUCKET"
 ```
+
+```
+You will then get a message that looks like this:
+
+Do you want to copy existing state to the new backend?
+  Pre-existing state was found while migrating the previous "local" backend to the
+  newly configured "s3" backend. No existing state was found in the newly
+  configured "s3" backend. Do you want to copy this state to the new "s3"
+  backend? Enter "yes" to copy and "no" to start with an empty state.
+```
+
+Type "yes" to migrate your local tfstate file to the cloud.
+
+Now when you run `aws s3 ls` you should see 2 buckets listed.
+One bucket should be the name of the bucket you are using to track the sate file, and the other bucket name should be the one you created with your modified `main.tf` file.

--- a/terraform_state.md
+++ b/terraform_state.md
@@ -1,0 +1,28 @@
+## Terraform state and remote state
+
+If you list the contents of your directory, you'll see a file called
+terraform.tfstate. This file is called the Terraform state file, and it
+contains information on the resources that Terraform is managing.
+
+As you can imagine, the information in this file is important for all
+developers working with your Terraform-managed resources. So instead of using a
+local file, it would be better to store this in a remote location. We recommend
+using an S3 bucket for remote state. That bucket should be very locked down,
+since this file can contain sensitive information about your deployment.
+
+In the file `modules/s3backend/main.tf`, we have a configuration for an S3
+bucket that can be used as a backend for Terraform state. For the purposes of
+this tutorial, you can create that bucket by changing into `modules/s3backend`
+directory and running `tofu plan -out tfplan` and `tofu apply tfplan`. Remember
+that Terraform uses all the `.tf` files in the current directory, but not in
+subdirectories.
+
+To use that configuration as our backend, we need to configure the `terraform`
+block in our `main.tf` file. Change the existing block to something like this:
+
+```hcl
+```
+
+In this, we're keeping some of the configuration in outside of the main
+Terraform. That's because some information (in our case, the bucket name) is
+potentially sensitive and shouldn't be kept in a public repository. 

--- a/terraform_state.md
+++ b/terraform_state.md
@@ -17,6 +17,7 @@ directory and running `tofu plan -out tfplan` and `tofu apply tfplan`. Remember
 that Terraform uses all the `.tf` files in the current directory, but not in
 subdirectories. Be sure to remember the name you choose for the bucket, we will need it later
 to tell terraform where to find our state file.
+You will also need the aws region and you can use the `tofu show` command which will print out the aws region that the bucket is in.
 
 To use that configuration as our backend, we need to configure the `terraform`
 block in our `main.tf` file. Change the existing block to something like this:


### PR DESCRIPTION
Few comments:

1. Not sure if it is too much to have users modify the `main.tf` or if we should have a folder with one that has the backend configured
2. The region of the bucket for the state needs to be used/known. I am not sure if it would be better to hard-code the region of the bucket in `backend/main.tf` so then when we modify `first_bucket/main.tf` we know what to set, or if we should do something like "use `tofu show` to get the region of the state bucket" and then have users use that region for the backend stanza.
